### PR TITLE
Updated fastp params

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -32,10 +32,10 @@ process {
     withName: FASTP {
         ext.args   = [
             "-q ${params.fastp_phred_quality}",
-            "--cut_front",
-            "--cut_tail",
-            "--cut_mean_quality ${params.fastp_cut_mean_quality}",
-            "--length_required ${params.reads_minlength}"
+            "--length_required ${params.reads_minlength}",
+            "--trim_front1 ${params.trim_front_bases}",
+            "--trim_tail1 ${params.trim_tail_bases}",
+            "--dedup ${params.deduplication}",
         ].join(' ').trim()
         publishDir = [
             [

--- a/nextflow.config
+++ b/nextflow.config
@@ -21,8 +21,10 @@ params {
 
     // (ext.args defined in nextflow.config)
     fastp_phred_quality          = 20
-    fastp_cut_mean_quality       = 20
-    reads_minlength              = 15
+    reads_minlength              = 70
+    trim_front_bases             = 10
+    trim_tail_bases              = 10
+    deduplication                = true
 
     // MEGAHIT  - assembly options
     megahit_kmer_list            = "31,59,87,115,143"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://raw.githubusercontent.com/MDL/metabolt/master/nextflow_schema.json",
+    "$id": "https://raw.githubusercontent.com/muneebdev7/metabolt/master/nextflow_schema.json",
     "title": "MDL/metabolt pipeline parameters",
     "description": "Lightning fast & automated metagenomic pipeline powered by Nextflow",
     "type": "object",
@@ -229,12 +229,13 @@
             "properties": {
                 "adapter_fasta": {
                     "type": "string",
-                    "fa_icon": "far fa-file",
+                    "fa_icon": "far fa-file-archive",
                     "description": "Specify a FASTA file to trim adapter sequences in the read files."
                 },
                 "discard_trimmed_pass": {
                     "type": "boolean",
-                    "description": "read1/read2 output file name"
+                    "description": "read1/read2 output file name",
+                    "fa_icon": "far fa-save"
                 },
                 "save_trimmed_fail": {
                     "type": "boolean",
@@ -252,17 +253,29 @@
                     "fa_icon": "fas fa-greater-than-equal",
                     "description": "The PHRED quality value that a base is qualified. Default 20 means PHRED quality >=Q20 is qualified"
                 },
-                "fastp_cut_mean_quality": {
-                    "type": "integer",
-                    "default": 20,
-                    "fa_icon": "fas fa-greater-than-equal",
-                    "description": "The mean quality requirement option, ranging 1~36"
-                },
                 "reads_minlength": {
                     "type": "integer",
-                    "default": 15,
+                    "default": 70,
                     "fa_icon": "fas fa-ruler",
                     "description": "Reads shorter than length required (specified value) will be discarded"
+                },
+                "deduplication": {
+                    "type": "boolean",
+                    "default": true,
+                    "fa_icon": "fas fa-clone",
+                    "description": "Enable deduplication to drop the duplicated reads/pairs"
+                },
+                "trim_front_bases": {
+                    "type": "integer",
+                    "default": 10,
+                    "fa_icon": "fas fa-cut",
+                    "description": "Trimming how many bases in front for read1, default is 10"
+                },
+                "trim_tail_bases": {
+                    "type": "integer",
+                    "default": 10,
+                    "fa_icon": "fas fa-cut",
+                    "description": "Trimming how many bases in tail for read1, default is 10"
                 }
             },
             "fa_icon": "fas fa-cut"
@@ -296,7 +309,8 @@
                 "metabat2_min_contig_len": {
                     "type": "integer",
                     "default": 1500,
-                    "description": "Minimum length of contigs to include in binning process. Contigs shorter than the specified length will be excluded from the analysis"
+                    "description": "Minimum length of contigs to include in binning process. Contigs shorter than the specified length will be excluded from the analysis",
+                    "fa_icon": "fas fa-ruler"
                 },
                 "metabat2_seed": {
                     "type": "integer",


### PR DESCRIPTION
# PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Nextflow schema lint (`nf-core pipelines schema lint`).
- [x] Code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).

--- 

- [x] Added params for fastp module: https://github.com/muneebdev7/metabolt/labels/Update
 - --dedup
 - --trim_front1
 - --trim_tail1

`NOTE: removed the --cut_mean_quality param as it is similar to -q param` 